### PR TITLE
Add support for minor and patch release tags

### DIFF
--- a/.github/workflows/package-api-specification.yml
+++ b/.github/workflows/package-api-specification.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Make tarball
-      run: tar -cvzf "appgate-sdp-api-spec-$(echo $GITHUB_REF | grep -oP "v\d+$").tar.gz" *.y*ml
+      run: tar -cvzf "appgate-sdp-api-spec-$(echo $GITHUB_REF | grep -oP "(v\d+)(\.\d+)?(\.\d+)?$").tar.gz" *.y*ml
     - name: Upload tarball
       uses: softprops/action-gh-release@v1
       if: startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
Improve regex to account for new versioning when creating the tarball name. Should now support all three variants of
- v16
- v16.1
- v16.1.1